### PR TITLE
Fix backend connection and frontend serving

### DIFF
--- a/Backend/DB/Connection.js
+++ b/Backend/DB/Connection.js
@@ -1,9 +1,10 @@
 var express = require("express");
 var bodyParser = require("body-parser");
 var mongoose = require("mongoose");
+const path = require("path");
 const app = express();
 app.use(bodyParser.json());
-app.use(express.static('FrontEnd'));
+app.use(express.static(path.join(__dirname, '../../FrontEnd/build/')));
 app.use(bodyParser.urlencoded({ 
     extended: true
 }));
@@ -11,13 +12,16 @@ mongoose.connect('mongodb://127.0.0.1/InfluencerMania');
 var db=mongoose.connection;
     db.on('error',()=>console.log("Error in Connecting to the database"));
 if(db.once('open',()=>console.log("Connected to the database")));
-app.get("/Signin",(req,res) => {
-  return res.render('Signin');
-});
-app.get("/Home",(req,res) => {
-  return res.render('Home');
-});
-app.post("/Signin",(req,res) => {
+// app.get("/signin",(req,res) => {
+//   return res.render('Signin');
+// });
+// app.get("/Home",(req,res) => {
+//   return res.render('Home');
+// });
+app.get("*", (req, res) => {
+    res.sendFile(path.join(__dirname, "../../Frontend/build/index.html"))
+})
+app.post("/signin",(req,res) => {
   var fname=req.body.fname;
   var lname=req.body.lname;
   var uname=req.body.uname;
@@ -35,14 +39,14 @@ app.post("/Signin",(req,res) => {
       }
       console.log("Record inserted  succesfully");
   });
-  return res.redirect('/');
+  return res.redirect('/Home/');
 })
 
-app.get("/", (req, res) => {
+app.get("*", (req, res) => {
     res.set({
       "Allow-access-Allow-Origin": "*",
     });
-    return res.redirect('/');
+    return res.redirect('/Home/');
   })
-  .listen(3000);
-console.log("Listening on port 3000");
+  .listen(8800);
+console.log("Listening on port 8800");

--- a/Backend/node_modules/.package-lock.json
+++ b/Backend/node_modules/.package-lock.json
@@ -474,6 +474,7 @@
         "bson": "^4.6.2",
         "denque": "^2.0.1",
         "mongodb-connection-string-url": "^2.5.2",
+        "saslprep": "^1.0.3",
         "socks": "^2.6.2"
       },
       "engines": {

--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -483,6 +483,7 @@
         "bson": "^4.6.2",
         "denque": "^2.0.1",
         "mongodb-connection-string-url": "^2.5.2",
+        "saslprep": "^1.0.3",
         "socks": "^2.6.2"
       },
       "engines": {

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -4,7 +4,7 @@
     "mongoose": "^6.3.3"
   },
   "scripts": {
-    "start": "node server.js"
+    "start": "npm run build --prefix ../FrontEnd && node ./DB/Connection.js"
   },
   "name": "backend",
   "version": "1.0.0",

--- a/FrontEnd/package-lock.json
+++ b/FrontEnd/package-lock.json
@@ -5782,6 +5782,7 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -7178,7 +7179,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -8567,6 +8569,7 @@
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.2.9.tgz",
       "integrity": "sha512-XMP4Z5j9KlGw8aeo7n8BXTJFbt1Vv5XRzHVOKiAna1yBG4SPwTdk/8bJRfztYb0Jmw90hzBTC/3Q2dhfdtXisQ==",
       "dependencies": {
+        "@emotion/is-prop-valid": "^0.8.2",
         "framesync": "6.0.1",
         "hey-listen": "^1.0.8",
         "popmotion": "11.0.3",
@@ -10400,6 +10403,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^27.5.1",
         "jest-serializer": "^27.5.1",
@@ -11644,6 +11648,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -12107,6 +12112,7 @@
         "bson": "^4.6.2",
         "denque": "^2.0.1",
         "mongodb-connection-string-url": "^2.5.2",
+        "saslprep": "^1.0.3",
         "socks": "^2.6.2"
       },
       "engines": {
@@ -14609,6 +14615,7 @@
         "eslint-webpack-plugin": "^3.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.0.0",
+        "fsevents": "^2.3.2",
         "html-webpack-plugin": "^5.5.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^27.4.3",
@@ -15020,6 +15027,9 @@
       "version": "2.70.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
       "integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+      "dependencies": {
+        "fsevents": "~2.3.2"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/FrontEnd/src/App.js
+++ b/FrontEnd/src/App.js
@@ -20,10 +20,11 @@ const App = () => {
 					<Route path="/ourwork" element={<Ourpeople/>}/>
 					<Route path="/strategy" element={<Ourpeople/>}/>
 					<Route path="/insights" element={<Ourpeople/>}/>
-					<Route path="/signin" element={<Signin/>}/>
+						<Route path="/signin" element={<Signin/>}/>
 					<Route path="/contact" element={<Contact/>}/>
 					<Route path="/login" element={<Login/>}/>
 					<Route path="/" element={<Home/>}/>
+					<Route path="/Home" element={<Home/>}/>
 				</Routes>
 				<FooterContainer/>
 			</Router>

--- a/FrontEnd/src/components/Signin.js
+++ b/FrontEnd/src/components/Signin.js
@@ -24,7 +24,7 @@ const Signin = () => {
   const btnstyle = { backgroundColor: "#867FF4", margin: "10px 0px" };
   return (
     <>
-    <Form action="/signin" method="POST">
+    <Form action="signin" method="POST">
       <Grid>
         <Paper elevation={10} style={paperStyle}>
           <Grid align="center">


### PR DESCRIPTION
Change backend serving logic - 
 - Original conflict was due to the react dev server running at port `3000`, causing conflicts with the express server also running at `3000`. No requests were being passed to the express server, all were intercepted by the react dev server on the same port.
 - `res.render()` is not the right method to serve React files. React build files need to be served from `FrontEnd/build/`
 - Changed the build method to create a production build of the react bundle, then serve the files. `app.get("*", ...)` ensures that the react file is served on all routes. Client side routing should be handled by the frontend, not backend
 - To run the app, simply run `npm run start` inside the `Backend/` directory. Do not run any command inside `FrontEnd`. The command will automatically build the react files for you.
 - The app will be served at `http://localhost:8800` (i.e port `8800`)